### PR TITLE
Security fixes for the friendly_id gem

### DIFF
--- a/test/compatibility/threading/Gemfile
+++ b/test/compatibility/threading/Gemfile
@@ -3,6 +3,6 @@ source :rubygems
 gem "pg"
 gem "mysql2"
 gem "mocha"
-gem "activerecord", "3.1.1"
+gem "activerecord", "3.2.22.1"
 gem "sqlite3"
 gem "fatalistic"

--- a/test/compatibility/threading/Gemfile
+++ b/test/compatibility/threading/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem "pg"
 gem "mysql2"
 gem "mocha"
-gem "activerecord", "3.2.22.1"
+gem "activerecord", "3.2.22.5"
 gem "sqlite3"
 gem "fatalistic"

--- a/test/compatibility/threading/Gemfile
+++ b/test/compatibility/threading/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "pg"
 gem "mysql2"

--- a/test/compatibility/threading/Gemfile.lock
+++ b/test/compatibility/threading/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (3.2.22.1)
-      activesupport (= 3.2.22.1)
+    activemodel (3.2.22.5)
+      activesupport (= 3.2.22.5)
       builder (~> 3.0.0)
-    activerecord (3.2.22.1)
-      activemodel (= 3.2.22.1)
-      activesupport (= 3.2.22.1)
+    activerecord (3.2.22.5)
+      activemodel (= 3.2.22.5)
+      activesupport (= 3.2.22.5)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activesupport (3.2.22.1)
+    activesupport (3.2.22.5)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.3)
@@ -31,7 +31,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (= 3.2.22.1)
+  activerecord (= 3.2.22.5)
   fatalistic
   mocha
   mysql2

--- a/test/compatibility/threading/Gemfile.lock
+++ b/test/compatibility/threading/Gemfile.lock
@@ -1,37 +1,42 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.1.1)
-      activesupport (= 3.1.1)
+    activemodel (3.2.22.1)
+      activesupport (= 3.2.22.1)
       builder (~> 3.0.0)
-      i18n (~> 0.6)
-    activerecord (3.1.1)
-      activemodel (= 3.1.1)
-      activesupport (= 3.1.1)
-      arel (~> 2.2.1)
+    activerecord (3.2.22.1)
+      activemodel (= 3.2.22.1)
+      activesupport (= 3.2.22.1)
+      arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activesupport (3.1.1)
+    activesupport (3.2.22.1)
+      i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    arel (2.2.1)
-    builder (3.0.0)
+    arel (3.0.3)
+    builder (3.0.4)
+    concurrent-ruby (1.1.5)
     fatalistic (0.0.1)
-    i18n (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     metaclass (0.0.1)
     mocha (0.10.0)
       metaclass (~> 0.0.1)
-    multi_json (1.0.3)
+    multi_json (1.14.1)
     mysql2 (0.3.11)
     pg (0.11.0)
     sqlite3 (1.3.5)
-    tzinfo (0.3.31)
+    tzinfo (0.3.56)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (= 3.1.1)
+  activerecord (= 3.2.22.1)
   fatalistic
   mocha
   mysql2
   pg
   sqlite3
+
+BUNDLED WITH
+   1.17.3

--- a/test/compatibility/threading/Gemfile.lock
+++ b/test/compatibility/threading/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activemodel (3.2.22.1)
       activesupport (= 3.2.22.1)


### PR DESCRIPTION
@change/pack-productivity-tools  @quaelin 

I had to run this on 1.9.3 since it had an old version of the mysql gem

`docker run -it --volume=`pwd`:/friendly_id corgibytes/ruby-1.9.3 bash`

before:
```
bundler-audit
Insecure Source URI found: http://rubygems.org/
Name: activerecord
Version: 3.1.1
Advisory: CVE-2015-7577
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/cawsWcQ6c8g
Title: Nested attributes rejection proc bypass in Active Record
Solution: upgrade to >= 5.0.0.beta1.1, ~> 4.2.5, >= 4.2.5.1, ~> 4.1.14, >= 4.1.14.1, ~> 3.2.22.1

Name: activerecord
Version: 3.1.1
Advisory: CVE-2012-2660
Criticality: High
URL: http://www.osvdb.org/show/osvdb/82610
Title: Ruby on Rails ActiveRecord Class Rack Query Parameter Parsing SQL Query Arbitrary IS NULL Clause Injection
Solution: upgrade to ~> 3.0.13, ~> 3.1.5, >= 3.2.4

Name: activerecord
Version: 3.1.1
Advisory: CVE-2012-6496
Criticality: Medium
URL: https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-security/DCNTNp_qjFM
Title: Ruby on Rails find_by_* Methods Authlogic SQL Injection Bypass
Solution: upgrade to ~> 3.0.18, ~> 3.1.9, >= 3.2.10

Name: activerecord
Version: 3.1.1
Advisory: CVE-2013-0276
Criticality: Medium
URL: http://osvdb.org/show/osvdb/90072
Title: Ruby on Rails Active Record attr_protected Method Bypass
Solution: upgrade to ~> 2.3.17, ~> 3.1.11, >= 3.2.12

Name: activerecord
Version: 3.1.1
Advisory: CVE-2013-1854
Criticality: High
URL: http://osvdb.org/show/osvdb/91453
Title: Symbol DoS vulnerability in Active Record
Solution: upgrade to ~> 2.3.18, ~> 3.1.12, >= 3.2.13

Name: activerecord
Version: 3.1.1
Advisory: CVE-2013-0155
Criticality: High
URL: http://osvdb.org/show/osvdb/89025
Title: Ruby on Rails Active Record JSON Parameter Parsing Query Bypass
Solution: upgrade to ~> 2.3.16, ~> 3.0.19, ~> 3.1.10, >= 3.2.11

Name: activerecord
Version: 3.1.1
Advisory: CVE-2014-3482
Criticality: Unknown
URL: http://osvdb.org/show/osvdb/108664
Title: SQL Injection Vulnerability in Active Record
Solution: upgrade to ~> 3.2.19

Name: activerecord
Version: 3.1.1
Advisory: CVE-2012-2661
Criticality: Medium
URL: http://www.osvdb.org/show/osvdb/82403
Title: Ruby on Rails where Method ActiveRecord Class SQL Injection
Solution: upgrade to ~> 3.0.13, ~> 3.1.5, >= 3.2.4

Name: activesupport
Version: 3.1.1
Advisory: CVE-2012-1098
Criticality: Medium
URL: http://osvdb.org/79726
Title: Ruby on Rails SafeBuffer Object [] Direct Manipulation XSS
Solution: upgrade to ~> 3.0.12, ~> 3.1.4, >= 3.2.2

Name: activesupport
Version: 3.1.1
Advisory: CVE-2013-1856
Criticality: High
URL: http://www.osvdb.org/show/osvdb/91451
Title: XML Parsing Vulnerability affecting JRuby users
Solution: upgrade to ~> 3.1.12, >= 3.2.13

Name: activesupport
Version: 3.1.1
Advisory: CVE-2012-3464
Criticality: Medium
URL: http://www.osvdb.org/show/osvdb/84516
Title: Ruby on Rails HTML Escaping Code XSS
Solution: upgrade to ~> 3.0.17, ~> 3.1.8, >= 3.2.8

Name: activesupport
Version: 3.1.1
Advisory: CVE-2015-3227
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/bahr2JLnxvk
Title: Possible Denial of Service attack in Active Support
Solution: upgrade to >= 4.2.2, ~> 4.1.11, ~> 3.2.22

Name: i18n
Version: 0.6.0
Advisory: CVE-2013-4492
Criticality: Medium
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/pLrh6DUw998
Title: i18n missing translation error message XSS
Solution: upgrade to ~> 0.5.1, >= 0.6.6
```

After:
```
bundler-audit
No vulnerabilities found
```

